### PR TITLE
02 network configuration fix

### DIFF
--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -151,9 +151,8 @@ ramips_setup_interfaces()
 		;;
 	tplink,archer-mr200-v4)
 		ucidef_add_switch "switch0" \
-			"0:lan" "1:lan" "2:lan" "3:lan" "6t@eth0"
-		ucidef_set_interface_wan "wwan0"
-		;;
+            "1:lan" "2:lan" "3:lan" "4:wan" "6t@eth0"
+        ;;
 	tplink,tl-mr3020-v3)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"


### PR DESCRIPTION
In the previous configuration I was unable to tag the wan port, from what I can tell the wan port was treated as a dedicated wan port rather than part of the lan switch. 

After merging the original switch layout from @marhaav's project it seems that the VLAN tagging is working as expected. 
